### PR TITLE
static checking: add a minimal configuration for flake8

### DIFF
--- a/nonos/main.py
+++ b/nonos/main.py
@@ -4,7 +4,7 @@
 adapted from pbenitez-llambay, gwafflard-fernandez, cmt robert & glesur
 """
 
-from multiprocessing import Pool, Value
+from multiprocessing import Pool
 from pathlib import Path
 from shutil import copyfile
 import functools
@@ -868,7 +868,8 @@ class StreamNonos(FieldNonos):
             sign = -1
         vr = self.get_v(vx,x,y)
         vt = self.get_v(vy,x,y)
-        if vt == None or vr == None: #Avoiding problems...
+        if None in (vt, vr):
+            #Avoiding problems...
             return None,None
 
         l = np.min((((self.x.max()-self.x.min())/self.nx),((self.y.max()-self.y.min())/self.ny)))

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,3 +33,27 @@ python_requires = >=3.8
 [options.entry_points]
 console_scripts =
     nonos = nonos.main:main
+
+[flake8]
+exclude = nonos/__init__.py
+ignore = E203, E501, W503,
+    # TODO: fix those manually
+    W605,
+    E741,
+    # formatting nitpicks (all of those can be solved with black)
+    E123,
+    E128,
+    E211,
+    E221,
+    E225,
+    E226,
+    E228,
+    E231,
+    E241,
+    E251,
+    E261,
+    E262,
+    E265,
+    E302,
+    E303,
+    W291,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 from nonos.main import main, AnalysisNonos
 import os
-import toml
 
 def test_no_inifile(capsys, tmp_path):
     os.chdir(tmp_path)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,5 +1,4 @@
-from nonos import InitParamNonos, FieldNonos
-import os
+from nonos import InitParamNonos
 import pytest
 
 def test_init_params_wo_a_file(tmp_path):


### PR DESCRIPTION
Completely ignoring formatting nitpicks that can be solved automatically, I wrote a minimal config for flake8 which allows to detect noise and potentially critical errors (undefined variable, unused imports...)

Here's the result of a run so far.
```shell
$ flake8 .
./nonos/main.py:7:1: F401 'multiprocessing.Value' imported but unused
./nonos/main.py:871:15: E711 comparison to None should be 'if cond is None:'
./tests/test_errors.py:1:1: F401 'nonos.FieldNonos' imported but unused
./tests/test_errors.py:2:1: F401 'os' imported but unused
./tests/test_cli.py:3:1: F401 'toml' imported but unused
```
I'll fix those in the same PR, and next time we can add the check to CI to improve stability.
edit: done