### PR TITLE
Output file(s) selection system revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,52 +36,61 @@ To get help, run
 $ nonos --help
 ```
 ```
-usage: nonos [-h] [-mode {d,f}] [-dir DATADIR] [-on ONSTART] [-field {RHO,VX1,VX2,VX3}] [-vmin VMIN] [-vmax VMAX] [-diff] [-log] [-isp] [-corotate]
-             [-grid] [-streamlines] [-rz] [-noavr] [-pbar] [-stype {random,fixed,lic}] [-srmin RMINSTREAM] [-srmax RMAXSTREAM] [-sn NSTREAMLINES]
-             [-geom {cartesian,polar} | -pol] [-dim {1,2}] [-ft FONTSIZE] [-cmap CMAP] [-cpu NCPU] [-onEnd ONEND] [-onStep ONSTEP]
-             [-input INPUT | -isolated] [-version | -logo | -config]
+usage: nonos [-h] [-dir DATADIR] [-field {RHO,VX1,VX2,VX3}] [-vmin VMIN]
+             [-vmax VMAX] [-cpu NCPU] [-on ON [ON ...] | -all] [-diff] [-log]
+             [-isp] [-corotate] [-grid] [-streamlines] [-rz] [-noavr] [-pbar]
+             [-stype {random,fixed,lic}] [-srmin RMINSTREAM]
+             [-srmax RMAXSTREAM] [-sn NSTREAMLINES]
+             [-geom {cartesian,polar} | -pol] [-dim {1,2}] [-ft FONTSIZE]
+             [-cmap CMAP] [-input INPUT | -isolated]
+             [-version | -logo | -config]
 
 Analysis tool for idefix/pluto/fargo3d simulations (in polar coordinates).
 
 optional arguments:
   -h, --help            show this help message and exit
-  -mode {d,f}           [d]isplay a single frame (default), or save a [f]ilm (sequence of frames).
-  -dir DATADIR          location of output files and param files (default: '.').
-  -on ONSTART, -onStart ONSTART
-                        output number (on) of the data file (default: 1).
+  -dir DATADIR          location of output files and param files (default:
+                        '.').
   -field {RHO,VX1,VX2,VX3}
                         name of field to plot (default: 'RHO').
   -vmin VMIN            min value in -diff mode (default: -0.5)
   -vmax VMAX            max value in -diff mode (default: -0.5)
+  -cpu NCPU, -ncpu NCPU
+                        number of parallel processes (default: 1).
+  -on ON [ON ...]       output number(s) (on) to plot. This can be a single
+                        value or a range (start, end, [step]) where both ends
+                        are inclusive. (default: last output available).
+  -all                  save an image for every available snapshot (this will
+                        force show=False).
   -geom {cartesian,polar}
   -pol                  shortcut for -geom=polar
-  -dim {1,2}            dimensionality in projection: 1 for a line plot, 2 (default) for a map.
+  -dim {1,2}            dimensionality in projection: 1 for a line plot, 2
+                        (default) for a map.
   -ft FONTSIZE          fontsize in the graph (default: 11).
-  -cmap CMAP            choice of colormap for the -dim 2 maps (default: 'RdYlBu_r').
+  -cmap CMAP            choice of colormap for the -dim 2 maps (default:
+                        'RdYlBu_r').
 
 boolean flags:
-  -diff                 plot the relative perturbation of the field f, i.e. (f-f0)/f0.
+  -diff                 plot the relative perturbation of the field f, i.e.
+                        (f-f0)/f0.
   -log                  plot the log10 of the field f, i.e. log(f).
   -isp                  is there a planet in the grid ?
   -corotate             does the grid corotate? Works in pair with -isp.
   -grid                 show the computational grid.
   -streamlines          plot streamlines.
-  -rz                   2D plot in the (R-z) plane (default: represent the midplane).
+  -rz                   2D plot in the (R-z) plane (default: represent the
+                        midplane).
   -noavr, -noaverage    do not perform averaging along the third dimension.
-  -pbar                 show a progress bar in film mode.
+  -pbar                 display a progress bar
 
 streamlines options:
   -stype {random,fixed,lic}, -streamtype {random,fixed,lic}
                         streamlines method (default: 'unset')
-  -srmin RMINSTREAM     minimum radius for streamlines computation (default: 0.7).
-  -srmax RMAXSTREAM     maximum radius for streamlines computation (default: 1.3).
+  -srmin RMINSTREAM     minimum radius for streamlines computation (default:
+                        0.7).
+  -srmax RMAXSTREAM     maximum radius for streamlines computation (default:
+                        1.3).
   -sn NSTREAMLINES      number of streamlines (default: 50).
-
-film mode options:
-  -cpu NCPU, -ncpu NCPU
-                        number of parallel processes (default: 1).
-  -onEnd ONEND          specify the last output number (last one available by default).
-  -onStep ONSTEP        render every `onStep` output number (default: 1).
 
 CLI-only options:
   -input INPUT, -i INPUT
@@ -116,20 +125,16 @@ As of Nonos 0.2.0, this will print
 ```
 # Generated with nonos 0.2.0
 datadir               =  "."
-mode                  =  "d"
 field                 =  "RHO"
 dimensionality        =  2
-onStart               =  1
-onEnd                 =  "unset"
-onStep                =  1
+on                    =  "unset"
 diff                  =  true
 log                   =  false
 vmin                  =  -10.0
 vmax                  =  100.0
 rz                    =  true
 noaverage             =  false
-streamlines           =  false
-streamtype            =  "random"
+streamtype            =  "unset"
 rminStream            =  0.7
 rmaxStream            =  1.3
 nstreamlines          =  50

--- a/nonos/config.py
+++ b/nonos/config.py
@@ -1,18 +1,12 @@
 DEFAULTS = {
     # directory where the simulation results are stored
     'datadir': '.',
-    # mode can be d (display), f (film)
-    'mode': 'd',
     # which field?
     'field': 'RHO',
     # 1D axisymmetric porfile or 2D map
     'dimensionality': 2,
-    # first output number ('on') to plot
-    'onStart': 1,
-    # last output number to use in film mode
-    'onEnd': 'unset',
-    # output number interval between used snapshot in film mode
-    'onStep': 1,
+    # a single output number ('on') to display or a range (min, max, [step])
+    'on': 'unset',
     # perturbation of field
     'diff': False,
     # field in log

--- a/nonos/parsing.py
+++ b/nonos/parsing.py
@@ -1,0 +1,40 @@
+from typing import Sequence, Union, List, Any, Optional, Dict, Tuple
+import numpy as np
+
+def is_set(x:Any) -> bool:
+    return x not in (None, 'unset')
+
+def parse_output_number_range(on:Optional[Union[List[int], int, str]], maxval:Optional[int]=None) -> List[int]:
+    if not is_set(on):
+        if maxval is None:
+            raise ValueError("Can't parse a range from unset values without a max.")
+        return [maxval]
+
+    if not isinstance(on, list):
+        if isinstance(on, int):
+            return [on]
+
+    if len(on) > 3:
+        raise ValueError(f"Can't parse a range from sequence {on} with more than 3 values.")
+    if len(on) == 1:
+        return on
+
+    if on[1] < on[0]:
+        raise ValueError("Can't parse a range with max < min.")
+
+    # make the upper boundary inclusive
+    on[1] += 1
+    ret = list(range(*on))
+    if maxval is not None and (max_requested := ret[-1]) > maxval:
+        raise ValueError(f"No output beyond {maxval} is available, but {max_requested} was requested.")
+    return ret
+
+
+def parse_vmin_vmax(vmin, vmax, diff:bool, data:np.ndarray, defaults:Dict[str, Any]) -> Tuple[float, float]:
+    if not is_set(vmin):
+        vmin = data.min() if not diff else defaults['vmin']
+        assert is_set(vmin)
+    if not is_set(vmax):
+        vmax = data.max() if not diff else defaults['vmax']
+        assert is_set(vmax)
+    return vmin, vmax

--- a/tests/test_load_config.py
+++ b/tests/test_load_config.py
@@ -28,9 +28,6 @@ def minimal_paramfile(tmp_path):
     return ifile
 
 def test_load_config_file(minimal_paramfile, capsys):
-    init = InitParamNonos(paramfile=minimal_paramfile)
-    assert init.config["dimensionality"] == 1
-
     os.chdir(minimal_paramfile.parent)
     ret = main(["-input", "nonos.toml", "-config"])
     

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,40 @@
+import re
+import pytest
+from nonos.parsing import parse_output_number_range
+
+@pytest.mark.parametrize(
+    "received, expected", [
+        (1, [1]),
+        (0, [0]),
+        ([0, 1], [0, 1]),
+        ([0, 2], [0, 1, 2]),
+        ([0, 5], [0, 1, 2, 3, 4, 5]),
+        ([10, 20, 5], [10, 15, 20]),
+        ([0, 299, 50], [0, 50, 100, 150, 200, 250]),
+    ]
+)
+def test_range_outputs(received, expected):
+    assert parse_output_number_range(received) == expected
+
+def test_unparseable_data():
+    with pytest.raises(ValueError, match="Can't parse a range from unset values without a max."):
+        parse_output_number_range('unset')
+
+def test_invalid_request():
+    with pytest.raises(ValueError, match="No output beyond 5 is available, but 10 was requested."):
+        parse_output_number_range([1, 10], maxval=5)
+
+def test_invalid_nargs():
+    with pytest.raises(ValueError, match=re.escape("Can't parse a range from sequence [1, 2, 3, 4] with more than 3 values.")):
+        parse_output_number_range([1, 2, 3, 4])
+
+@pytest.mark.parametrize(
+    "received", [
+        [1, 0],
+        [1, 0, 1],
+        [1, 0, 2],
+    ]
+)
+def test_invalid_range(received):
+    with pytest.raises(ValueError, match="Can't parse a range with max < min."):
+        parse_output_number_range(received)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 import pytest
 from nonos.main import main
@@ -7,42 +8,39 @@ from nonos.main import main
 def test_data_dir():
     return Path(__file__).parent / "data"
 
+@pytest.fixture(params=["idefix_rwi", "idefix_planet3d"])
+def simulation_dir(test_data_dir, request):
+    return test_data_dir / request.param
+
 ARGS_TO_CHECK = {
     "vanilla_conf": [],
     "diff": ["-diff"],
     "log": ["-log"],
-    "movie": ["-mod", "f", "-pol"],
-    "movie_with_diff": ["-mod", "f", "-diff"],
-    "movie_with_multiproc": ["-mod", "f", "-ncpu", "2"],
+    "movie": ["-all", "-pol"],
+    "movie_with_diff": ["-all", "-diff"],
+    "movie_with_multiproc": ["-all", "-ncpu", "2"],
 }
 
 @pytest.mark.parametrize("argv", ARGS_TO_CHECK.values(), ids=ARGS_TO_CHECK.keys())
-def test_plot_simple(argv, test_data_dir, capsys):
+def test_plot_simple(argv, simulation_dir, capsys):
     # just check that the call returns no err
-    os.chdir(test_data_dir / "idefix_rwi") 
-    ret = main(argv, show=False)
+    ret = main(argv + ["-dir", str(simulation_dir)], show=False)
 
     out, err = capsys.readouterr()
-    print(out)
     assert err == ""
-    if "f" in argv:
-        assert out.startswith("time")
-        assert out.count("\n") == 1
-    else:
-        assert out == ""
+    assert re.match(r"Operation took \d.\d\ds\n", out)
     assert ret == 0
 
-def test_plot_simple_corotation(test_data_dir, capsys):
+def test_plot_simple_corotation(simulation_dir, capsys):
     # just check that the call returns no err
-    os.chdir(test_data_dir / "idefix_rwi") 
-    ret = main(["-mod", "d", "-cor"], show=False)
-    assert ret == 0
+    ret = main(["-cor", "-dir", str(simulation_dir)], show=False)
 
     out, err = capsys.readouterr()
-    assert out == ""
+    assert re.match(r"Operation took \d.\d\ds\n", out)
     # ignore differences in text wrapping because they are an implementation detail
     # due to the fact we use rich to display warnings
     assert err.strip().replace("\n", " ").endswith("We don't rotate the grid if there is no planet for now. omegagrid = 0.")
+    assert ret == 0
 
 def test_plot_planet_corotation(test_data_dir):
     from nonos import InitParamNonos, FieldNonos


### PR DESCRIPTION
fix #16
Replace `-mod`, `-onStart`, `-onEnd` and `-onStep` arguments with a single `-on` argument with some magic.

I realised that there's no easy replacement for
```shell
$ nonos -mod f
```
which means "grab everything you want and save an image", but I also note that this mode is a bit fragile because it won't work if some dump files are missing. For now, I'm replacing it with a `-film` arg, that I hope to be able to remove later, and which is implemented to be incompatible with this generalised `-on` param.

TODO
- [x] fix a bug discovered in this PR where some objects incorrectly use `paramfile="nonos.toml"` by default instead of e.g. `idefix.ini`
- [x] get rid of the `-film` param
- [x] cleanup the temporary property `n_files`
- [x] improve decision making in wether or not to display each image. Right now images are displayed one after the other even when more than on is requested
- [x] rebase
- [x] Update README.md