### PR TITLE
expose image format selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ usage: nonos [-h] [-dir DATADIR] [-field {RHO,VX1,VX2,VX3}] [-vmin VMIN]
              [-stype {random,fixed,lic}] [-srmin RMINSTREAM]
              [-srmax RMAXSTREAM] [-sn NSTREAMLINES]
              [-geom {cartesian,polar} | -pol] [-dim {1,2}] [-ft FONTSIZE]
-             [-cmap CMAP] [-dpi DPI] [-input INPUT | -isolated]
+             [-cmap CMAP] [-fmt FORMAT] [-dpi DPI] [-input INPUT | -isolated]
              [-d | -version | -logo | -config]
 
 Analysis tool for idefix/pluto/fargo3d simulations (in polar coordinates).
@@ -69,6 +69,8 @@ optional arguments:
   -ft FONTSIZE          fontsize in the graph (default: 11).
   -cmap CMAP            choice of colormap for the -dim 2 maps (default:
                         'RdYlBu_r').
+  -fmt FORMAT, -format FORMAT
+                        select output image file format (default: unset)
   -dpi DPI              image file resolution (default: DEFAULTS['dpi'])
 
 boolean flags:

--- a/nonos/config.py
+++ b/nonos/config.py
@@ -43,6 +43,8 @@ DEFAULTS = {
     'fontsize': 11,
     # choice of colormap
     'cmap': 'RdYlBu_r',
+    # select image file format
+    'format': "unset",
     # select image resolution
     'dpi': 200,
 }

--- a/nonos/parsing.py
+++ b/nonos/parsing.py
@@ -36,3 +36,18 @@ def parse_vmin_vmax(vmin, vmax, diff:bool, data:np.ndarray) -> Tuple[float, floa
     if not is_set(vmax):
         vmax = -data.min() if diff else data.max()
     return vmin, vmax
+
+
+def parse_image_format(s: Optional[str]) -> str:
+    from matplotlib.backend_bases import FigureCanvasBase
+
+    if not is_set(s):
+        return FigureCanvasBase.get_default_filetype()
+
+    _, _, ext = s.rpartition(".")
+    if not ext in (available:=list(FigureCanvasBase.get_supported_filetypes().keys())):
+        raise ValueError(
+            f"Received unknown file format '{s}'. "
+            f"Available formated are {available}."
+        )
+    return ext

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,7 +1,7 @@
 import re
 import pytest
 import numpy as np
-from nonos.parsing import parse_output_number_range, parse_vmin_vmax
+from nonos.parsing import parse_output_number_range, parse_vmin_vmax, parse_image_format
 
 @pytest.mark.parametrize(
     "received, expected", [
@@ -61,3 +61,22 @@ def test_nodiff_parse_vmin_vmax(data, expected):
 
 def test_diff_parse_vmin_vmax(data, expected):
     assert parse_vmin_vmax('unset', 'unset', diff=True, data=data) == expected
+
+@pytest.mark.parametrize(
+    "received, expected", [
+        (".png", "png"),
+        (".pdf", "pdf"),
+        ("png", "png"),
+        ("pdf", "pdf"),
+    ]
+)
+def test_image_format(received, expected):
+    assert parse_image_format(received) == expected
+
+def test_invalid_image_format():
+    fake_ext = ".pnd"
+    with pytest.raises(
+        ValueError,
+        match="^(Received unknown file format '{}'. Available formated are)".format(fake_ext)
+        ):
+        parse_image_format(fake_ext)


### PR DESCRIPTION
fix #21
this is currently based ont top of #29 

TODO
- [x] merge #29 
- [x] change error message (It should say "available", not "supported" file formats, since it depends on matplotlib+the local system support, not Nonos itself)
- [x] add unit tests
- [x] add AB tests
- [x] update readme
- [x] rebase