### PR TITLE
bump inifix required version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    inifix>=0.4.2<0.5.0
+    inifix>=0.5.0<0.6.0
     lic
     matplotlib>=3.2.1
     numpy>=1.18.5


### PR DESCRIPTION
I just released inifix 0.5.0
Basically it doesn't change anything on nonos' side, but there's a fix in there.