### PR TITLE
MNT: add explicit support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9']
+        python-version: [
+          '3.8',
+          '3.9',
+          '3.10',
+        ]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,6 @@ repos:
     rev: v1.19.0
     hooks:
       - id: setup-cfg-fmt
-        args: [--max-py-version, '3.9']
 
   - repo: https://github.com/neutrinoceros/inifix.git
     rev: v0.9.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
@@ -24,7 +25,7 @@ install_requires =
     matplotlib>=3.2.1
     numpy>=1.18.5
     pytomlpp>=1.0.1
-    rich
+    rich>=10.13.0
     scikit-image>=0.18.1
     scipy>=1.6.1
 python_requires = >=3.8


### PR DESCRIPTION
Now that matplotlib 3.5.0 is out, there are wheels for Python 3.10 we can test against.
