### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,23 +15,23 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/neutrinoceros/inifix.git
-    rev: v1.0.0
+    rev: v1.2.0
     hooks:
       - id: inifix-validate
 
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/nonos/api/analysis.py
+++ b/nonos/api/analysis.py
@@ -268,7 +268,7 @@ class Coordinates:
                 y = R * np.sin(phi)
                 target_coords = {"x": x, "y": y, "z": z}
             elif target_geometry == "spherical":
-                r = np.sqrt(R ** 2 + z ** 2)
+                r = np.sqrt(R**2 + z**2)
                 theta = np.arctan2(R, z)
                 target_coords = {"r": r, "theta": theta, "phi": phi}
             else:
@@ -277,12 +277,12 @@ class Coordinates:
         elif self.geometry == "cartesian":
             x, y, z = (coords["x"], coords["y"], coords["z"])
             if target_geometry == "polar":
-                R = np.sqrt(x ** 2 + y ** 2)
+                R = np.sqrt(x**2 + y**2)
                 phi = np.arctan2(y, x)
                 target_coords = {"R": R, "phi": phi, "z": z}
             elif target_geometry == "spherical":
-                r = np.sqrt(x ** 2 + y ** 2 + z ** 2)
-                theta = np.arctan2(np.sqrt(x ** 2 + y ** 2), z)
+                r = np.sqrt(x**2 + y**2 + z**2)
+                theta = np.arctan2(np.sqrt(x**2 + y**2), z)
                 phi = np.arctan2(y, x)
                 target_coords = {"r": r, "theta": theta, "phi": phi}
             else:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -102,28 +102,22 @@ def test_parse_range(abscissa, ordinate, dim, expected):
     extent1 = parse_range("unset", dim=dim)
     assert range_converter(extent1, abscissa=abscissa, ordinate=ordinate) == expected
     extent2 = parse_range(("0.5", "5", "-0.2", "0.2"), dim=2)
-    assert (
-        range_converter(
-            extent2,
-            abscissa=np.linspace(0.2, 10, 100),
-            ordinate=np.linspace(-0.4, 0.4, 100),
-        )
-        == (0.5, 5, -0.2, 0.2)
-    )
+    assert range_converter(
+        extent2,
+        abscissa=np.linspace(0.2, 10, 100),
+        ordinate=np.linspace(-0.4, 0.4, 100),
+    ) == (0.5, 5, -0.2, 0.2)
     extent3 = parse_range(("0.4", "9.5"), dim=1)
     assert range_converter(
         extent3, abscissa=np.linspace(0.2, 10, 100), ordinate=np.zeros(2)
     ) == (0.4, 9.5)
     extent4 = parse_range(("0.5", "x", "-0.2", "x"), dim=2)
     assert extent4 == (0.5, None, -0.2, None)
-    assert (
-        range_converter(
-            extent4,
-            abscissa=np.linspace(0.2, 10, 100),
-            ordinate=np.linspace(-0.4, 0.4, 100),
-        )
-        == (0.5, 10.0, -0.2, 0.4)
-    )
+    assert range_converter(
+        extent4,
+        abscissa=np.linspace(0.2, 10, 100),
+        ordinate=np.linspace(-0.4, 0.4, 100),
+    ) == (0.5, 10.0, -0.2, 0.4)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This update is necessary because newest versions of click break black (see https://github.com/psf/black/issues/2964)
updating black is also going to cause small style changes that came with black 22