### PR TITLE
ENH: migrate to tomli + tomli_w, use standard library when possible

### DIFF
--- a/nonos/main.py
+++ b/nonos/main.py
@@ -8,6 +8,7 @@ import argparse
 import functools
 import os
 import re
+import sys
 import time
 from collections import ChainMap
 from multiprocessing import Pool
@@ -17,7 +18,7 @@ import cblind as cb
 import matplotlib.pyplot as plt
 import numpy as np
 import pkg_resources
-import pytomlpp as toml
+import tomli_w
 from inifix.format import iniformat
 
 from nonos.__version__ import __version__
@@ -32,6 +33,11 @@ from nonos.parsing import (
     range_converter,
 )
 from nonos.styling import set_mpl_style
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 # process function for parallisation purpose with progress bar
@@ -396,10 +402,12 @@ def main(argv: Optional[List[str]] = None) -> int:
             print_err(f"Couldn't find requested input file '{ifile}'.")
             return 1
         print_warn(f"[bold white]Using parameters from '{ifile}'.")
-        config_file_args = toml.load(ifile)
+        with open(ifile, "rb") as bh:
+            config_file_args = tomllib.load(bh)
     elif os.path.isfile("nonos.toml"):
         print_warn("[bold white]Using parameters from 'nonos.toml'.")
-        config_file_args = toml.load("nonos.toml")
+        with open("nonos.toml", "rb") as bh:
+            config_file_args = tomllib.load(bh)
     else:
         config_file_args = {}
 
@@ -417,7 +425,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         for key in DEFAULTS:
             conf_repr[key] = args[key]
         print(f"# Generated with nonos {__version__}")
-        print(iniformat(toml.dumps(conf_repr)))
+        print(iniformat(tomli_w.dumps(conf_repr)))
         return 0
 
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,10 +26,11 @@ install_requires =
     matplotlib>=3.2.1
     numpy>=1.18.5
     packaging>=21.3
-    pytomlpp>=1.0.1
     rich>=10.13.0
     scikit-image>=0.18.1
     scipy>=1.6.1
+    tomli-w>=0.4.0
+    tomli>=1.2.3;python_version < '3.11'
 python_requires = >=3.8
 
 [options.entry_points]
@@ -48,10 +49,11 @@ minimal =
     matplotlib==3.2.1
     numpy==1.18.5
     packaging==21.3
-    pytomlpp==1.0.1
     rich==10.13.0
     scikit-image==0.18.1
     scipy==1.6.1
+    tomli-w==0.4.0
+    tomli==1.2.3;python_version < '3.11'
 typecheck =
     mypy==0.931
     types-setuptools~=57.4.8

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,15 @@
 import os
+import sys
 import textwrap
-
-import pytomlpp as toml
 
 from nonos import __version__
 from nonos.api import Parameters
 from nonos.main import main
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 def test_no_inifile(capsys, tmp_path):
@@ -26,7 +30,7 @@ def test_default_conf(capsys, tmp_path):
 
     # validate output is reusable
     (tmp_path / "idefix.ini").touch()
-    dictout = toml.loads(out)
+    dictout = tomllib.loads(out)
     Parameters(directory=dictout["datadir"])
 
 

--- a/tests/test_load_config.py
+++ b/tests/test_load_config.py
@@ -2,11 +2,15 @@ import os
 import sys
 
 import pytest
-import pytomlpp as toml
 
 from nonos.api import Parameters
 from nonos.config import DEFAULTS
 from nonos.main import main
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="does not run on windows")
@@ -37,7 +41,7 @@ def test_load_config_file(minimal_paramfile, capsys):
     assert ret == 0
     out, err = capsys.readouterr()
     assert "Using parameters from" in err
-    conf = toml.loads(out)
+    conf = tomllib.loads(out)
     assert conf["field"] == "VX1"
 
 
@@ -48,5 +52,5 @@ def test_isolated_mode(minimal_paramfile, capsys):
     assert ret == 0
     out, err = capsys.readouterr()
     assert err == ""
-    conf = toml.loads(out)
+    conf = tomllib.loads(out)
     assert conf["field"] == DEFAULTS["field"]


### PR DESCRIPTION
[PEP 680](https://peps.python.org/pep-0680/) introduces a new `tomllib` module to the standard library.
It is implemented in current alpha versions of Python 3.11

tomli_w is needed as a complementary API, but it's pure Python, very light, and support is guaranteed for the time being.
Overall this migration makes it so we don't need to rely on `pytomlpp`'s to release new wheels every time Python sees a new version released, making nonos a little lighter and a little more future-proof.

An alternative approach would be to migrate from toml to ini(fix) config files, so we wouldn't need dependencies other than inifix, which I don't think we _can_ drop anyway.