### PR TITLE
TST: switch CI to Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,19 @@ on:
     # run this once a week (wednesday) at 3 am UTC
   - cron: 0 3 * * 3
   workflow_dispatch:
+
+
+
 jobs:
   tests:
     strategy:
+      fail-fast: false
       matrix:
         os:
         - ubuntu-latest
         - macos-latest
         - windows-latest
-        python-version: ['3.10']
+        python-version: ['3.11']
         include:
         - os: ubuntu-20.04
           python-version: '3.8'
@@ -50,7 +54,7 @@ jobs:
       matrix:
         python-version:
         - '3.8'
-        - '3.10'
+        - '3.11'
 
     runs-on: ubuntu-latest
     name: type-checking
@@ -79,7 +83,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.11'
 
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
This will probably not work just yet, depending how dependencies handled Python 3.11 compat thusfar