### PR TITLE
MNT: upgrade pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     args: [--py38-plus]
 
 - repo: https://github.com/neutrinoceros/inifix.git
-  rev: v3.0.0
+  rev: v4.0.0
   hooks:
   - id: inifix-format
 
@@ -29,7 +29,7 @@ repos:
     language_version: python3
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
   - id: isort
     additional_dependencies: [toml]
@@ -41,7 +41,7 @@ repos:
     additional_dependencies: [flake8-bugbear]
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.5.0
+  rev: v2.6.0
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']


### PR DESCRIPTION
context: isort needs to be upgraded because our currently pinned version is not compatible with Python 3.11, which is used in ci, see https://results.pre-commit.ci/run/github/348780729/1675286583.-x8J6rRSSJy2dfyvyCS7-Q