### PR TITLE
BLD: drop pkg_resources as a dependency on Python 3.8

### DIFF
--- a/nonos/main.py
+++ b/nonos/main.py
@@ -6,7 +6,6 @@ Analysis tool for idefix/pluto/fargo3d simulations (in polar coordinates).
 
 import argparse
 import functools
-import importlib.resources
 import os
 import re
 import sys
@@ -39,6 +38,11 @@ from nonos.parsing import (
     range_converter,
 )
 from nonos.styling import set_mpl_style
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 
 # process function for parallisation purpose with progress bar
@@ -387,13 +391,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     # special cases: destructively consume CLI-only arguments with dict.pop
 
     if clargs.pop("logo"):
-        if sys.version_info >= (3, 9):
-            logo = importlib.resources.files("nonos").joinpath("logo.txt").read_text()
-        else:
-            import pkg_resources
-
-            with pkg_resources.resource_stream("nonos", "logo.txt") as fh:
-                logo = fh.read().decode()
+        logo = importlib_resources.files("nonos").joinpath("logo.txt").read_text()
         print(f"{logo}{__doc__}Version {__version__}")
         return 0
 

--- a/nonos/styling.py
+++ b/nonos/styling.py
@@ -1,7 +1,11 @@
-import importlib.resources
 import sys
 
 import matplotlib as mpl
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 
 def scale_mpl(scaling: float) -> None:
@@ -50,12 +54,6 @@ def scale_mpl(scaling: float) -> None:
 
 
 def set_mpl_style(scaling: float) -> None:
-    if sys.version_info >= (3, 9):
-        stylesheet = importlib.resources.files("nonos") / "nonos.mplstyle"
-    else:
-        import pkg_resources
-
-        stylesheet = pkg_resources.resource_filename("nonos", "nonos.mplstyle")
-
+    stylesheet = importlib_resources.files("nonos") / "nonos.mplstyle"
     mpl.rc_file(stylesheet)
     scale_mpl(scaling)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "packaging>=21.3",
     "rich>=10.13.0",
     "scipy>=1.6.1",
+    "importlib_resources>=1.3; python_version < '3.9'"
 ]
 
 [project.license]

--- a/requirements/minimal_dependencies.txt
+++ b/requirements/minimal_dependencies.txt
@@ -7,3 +7,4 @@ numpy==1.18.5
 packaging==21.3
 rich==10.13.0
 scipy==1.6.1
+importlib_resources==1.3; python_version < '3.9'

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,2 +1,1 @@
 mypy==0.991
-types-setuptools~=57.4.8 # this is needed to typecheck pkg_resources usages. It should be removed when Python 3.8 is dropped


### PR DESCRIPTION
follow up to #131 