### PR TITLE
ENH: avoid deprecated cblind API

### DIFF
--- a/constraints/minimal_dependencies.txt
+++ b/constraints/minimal_dependencies.txt
@@ -1,4 +1,4 @@
-cblind==2.2.2
+cblind==2.3.0
 inifix==3.0.0
 lick==0.2.0
 loguru==0.5.3

--- a/nonos/main.py
+++ b/nonos/main.py
@@ -14,7 +14,7 @@ from collections import ChainMap
 from multiprocessing import Pool
 from typing import Any, Dict, List, Optional
 
-import cblind as cb
+import cblind  # noqa
 import inifix
 import numpy as np
 from inifix.format import iniformat
@@ -141,7 +141,7 @@ def process_field(
             log=log,
             vmin=vmin,
             vmax=vmax,
-            cmap=cb.cbmap(cmap, nbin=None),
+            cmap=cmap,
             title="$%s$" % title,
             unit_conversion=unit_conversion,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.8"
 
 # keep in sync with constraints/minimal_dependencies.txt
 dependencies = [
-    "cblind>=2.2.2",
+    "cblind>=2.3.0",
     "inifix>=3.0.0",
     "lick>=0.2.0",
     "loguru>=0.5.3",


### PR DESCRIPTION
Waiting for
- [x] https://github.com/volodia99/cblind/pull/6
- [x] a new cblind release