### PR TITLE
BUG: fix an insidious bug where nonos.styling.set_mpl_style silently relied on side effects to work with matplotlib >= 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,6 @@ plt.show()
 `nonos` CLI uses a custom style that can be reused programmatically, without
 importing the package, using matplotlib API
 ```python
-import matplotlib as mpl
-mpl.style.use("nonos.default")
-
-# alternatively
 import matplotlib.pyplot as plt
 plt.style.use("nonos.default")
 ```

--- a/nonos/styling.py
+++ b/nonos/styling.py
@@ -55,7 +55,9 @@ def scale_mpl(scaling: float) -> None:
 
 def set_mpl_style(scaling: float) -> None:
     if mpl.__version_info__ >= (3, 7):
-        mpl.style.use("nonos.default")
+        import matplotlib.pyplot as plt
+
+        plt.style.use("nonos.default")
     else:
         mpl.rc_file(importlib_resources.files("nonos") / "default.mplstyle")
     scale_mpl(scaling)


### PR DESCRIPTION
This was discovered thanks to newly supported type checking in matplotlib 3.8.0rc1

explanation: `matplotlib.style` is only defined at runtime *after* `pyplot` was imported. I also updated the documentation to avoid `AttributeErrors`