### PR TITLE
TST: simplify doc requirements

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,5 +1,3 @@
-. # install nonos too
-
 mkdocs==1.5.3
 mkdocs-material==9.4.7
 mkdocs-include-markdown-plugin==6.0.3


### PR DESCRIPTION
follow up to #223: I believe this requirement isn't supported by dependabot and explains why #217, #219 and #220 were closed. It's also not needed since we use a flat package layout (as opposed to a src layout)