### PR TITLE
TST: allow disabling multiprocessing via environment variable

### DIFF
--- a/nonos/main.py
+++ b/nonos/main.py
@@ -540,14 +540,18 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     logger.info("Starting main loop")
     tstart = time.time()
-    with Pool(ncpu) as pool:
-        list(
-            mytrack(
-                pool.imap(func, args["on"]),
-                description="Processing snapshots",
-                total=len(args["on"]),
+    if "NONOS_DEBUG" in os.environ:
+        for on in args["on"]:
+            func(on)
+    else:
+        with Pool(ncpu) as pool:
+            list(
+                mytrack(
+                    pool.imap(func, args["on"]),
+                    description="Processing snapshots",
+                    total=len(args["on"]),
+                )
             )
-        )
     if not show:
         logger.info("Operation took {:.2f}s", time.time() - tstart)
 


### PR DESCRIPTION
Rationale: this loops as a lot going on internally (hence, many failure modes) and multiprocessing + rich colorbars make traceback unhelpful. I find that when developping, I tend to reimplement this exact patch so I can run tests as
```shell
NONOS_DEBUG=1 pytest
```
and actually see where exceptions come from.