### PR TITLE
MNT: enable ruff's --show-fixes flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   rev: v0.3.0
   hooks:
   - id: ruff
-    args: [--fix]
+    args: [--fix, --show-fixes]
 
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v2.12.0


### PR DESCRIPTION
It's a lot nicer to see *what* ruff changed in pre-commit.