### PR TITLE
TST: generate coverage reports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,18 @@ jobs:
     - run: python -m pip list
 
     - name: Run pytest
-      run: pytest --color=yes
+      run: |
+        python -m coverage run --parallel-mode -m pytest --color=yes
 
+    - name: Upload coverage data
+      # only using reports from ubuntu because
+      # combining reports from multiple platforms is tricky (or impossible ?)
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v4
+      with:
+        name: nonos_coverage_data-${{ matrix.os }}-${{ matrix.python-version }}
+        path: .coverage.*
+        if-no-files-found: ignore
 
   type-check:
     strategy:
@@ -136,6 +146,38 @@ jobs:
         name: nonos_pytest_mpl_new_baseline
         path: nonos_pytest_mpl_new_baseline/*
         if-no-files-found: ignore
+
+  coverage:
+    name: Combine coverage reports
+    runs-on: ubuntu-latest
+    needs: tests
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        # Use latest Python, so it understands all syntax.
+        python-version: 3.x
+
+    - run: python -m pip install --upgrade coverage[toml]
+
+    - uses: actions/download-artifact@v4
+      with:
+        pattern: nonos_coverage_data-*
+        merge-multiple: true
+
+    - name: Check coverage
+      run: |
+        python -m coverage combine
+        python -m coverage html --skip-covered --skip-empty
+        python -m coverage report --fail-under=70
+
+    - name: Upload HTML report if check failed.
+      uses: actions/upload-artifact@v4
+      with:
+        name: nonos_coverage_report
+        path: htmlcov
+      if: ${{ failure() }}
 
 
   docs:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,3 +2,4 @@ cogapp>=3.3.0
 numexpr>=2.8.3
 pytest>=6.1
 pytest-mpl>=0.15.1
+coverage[toml]>=7.4.4


### PR DESCRIPTION
At the time of opening, I set it to fail CI if coverage is reported < 100%, which is currently the case. I intend to lower or remove this barrier once it's the only remaining failure mode.