### PR TITLE
BUG: avoid multiprocessing overhead when looping on a single worker

### DIFF
--- a/nonos/main.py
+++ b/nonos/main.py
@@ -46,7 +46,7 @@ else:
     import importlib_resources
 
 
-# process function for parallisation purpose with progress bar
+# process function for parallelisation purpose with progress bar
 # counterParallel = Value('i', 0) # initialization of a counter
 def process_field(
     on,
@@ -540,14 +540,18 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     logger.info("Starting main loop")
     tstart = time.time()
-    with Pool(ncpu) as pool:
-        list(
-            mytrack(
-                pool.imap(func, args["on"]),
-                description="Processing snapshots",
-                total=len(args["on"]),
+    if ncpu == 1:
+        for on in args["on"]:
+            func(on)
+    else:
+        with Pool(ncpu) as pool:
+            list(
+                mytrack(
+                    pool.imap(func, args["on"]),
+                    description="Processing snapshots",
+                    total=len(args["on"]),
+                )
             )
-        )
     if not show:
         logger.info("Operation took {:.2f}s", time.time() - tstart)
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -190,7 +190,7 @@ def test_pbar(simulation_dir, capsys, tmp_path):
 
     out, err = capsys.readouterr()
     assert err == ""
-    assert "Processing snapshots" in out
+    assert out == ""
     assert ret == 0
 
 


### PR DESCRIPTION
This is basically the same idea as #255, but I have a new motivation for it: `nonos.main::process_field` is currently marked as not covered in reports, but I'm almost certain that it's just because multiprocessing or rich destroys traceback data.
