### PR TITLE
TYP: typecheck against every supported Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       matrix:
         python-version:
         - '3.8'
+        - '3.9'
+        - '3.10'
+        - '3.11'
         - '3.12'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
I'm getting new, but seemingly unrelated type checking errors in #299, which I suspect would already happen on main, so let's try typechecking on all supported Python versions from now on