### PR TITLE
STY: migrate from black to ruff-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,10 @@ repos:
   hooks:
   - id: inifix-format
 
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 24.3.0
-  hooks:
-  - id: black
-
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.3.5
   hooks:
+  - id: ruff-format
   - id: ruff
     args: [--fix, --show-fixes]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![PyPI](https://img.shields.io/badge/requires-Python%20≥%203.8-blue?logo=python&logoColor=white)](https://pypi.org/project/nonos/)
 [![Documentation Status](https://readthedocs.org/projects/nonos/badge/?version=latest)](https://nonos.readthedocs.io/en/latest/?badge=latest)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/volodia99/nonos/main.svg)](https://results.pre-commit.ci/badge/github/volodia99/nonos/main.svg)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/charliermarsh/ruff)
 
 nonos is a 2D visualization command line application for planet-disk numerical simulations, as well as a Python library. It works with vtk-formatted data from Pluto and Idefix, and dat-formatted data for Fargo-adsg and Fargo3D.

--- a/nonos/_readers/binary.py
+++ b/nonos/_readers/binary.py
@@ -642,7 +642,6 @@ class FargoADSGReader(_FargoReader):
 
 
 class NPYReader(ReaderMixin):
-
     # we accept a leading '_' for backward compatibility
     _filename_re = re.compile(
         r"^_?(?P<prefix>[\w\.]*)"

--- a/nonos/_readers/ini.py
+++ b/nonos/_readers/ini.py
@@ -17,7 +17,6 @@ from nonos._types import FrameType, IniData, PathT
 class IdefixVTKReader(ReaderMixin):
     @staticmethod
     def read(file: PathT, /) -> IniData:
-
         class IdefixIniOutput:
             def __init__(self, *, vtk, **_kwargs) -> None:
                 self.vtk = float(vtk)

--- a/nonos/_types.py
+++ b/nonos/_types.py
@@ -57,7 +57,6 @@ class FrameType(Enum):
 @final
 @dataclass(frozen=True, eq=False)
 class BinData:
-
     # TODO: use slots=True in @dataclass when Python 3.9 is dropped
     __slots__ = ["data", "geometry", "x1", "x2", "x3"]
     data: StrDict

--- a/nonos/api/from_simulation.py
+++ b/nonos/api/from_simulation.py
@@ -757,9 +757,7 @@ class CodeReadFormat:
         if computedata:
             logger.debug("loading data arrays")
             while 1:
-                s = (
-                    fid.readline()
-                )  # SCALARS/VECTORS name data_type (ex: SCALARS imagedata unsigned_char)
+                s = fid.readline()  # SCALARS/VECTORS name data_type (ex: SCALARS imagedata unsigned_char)
                 # print repr(s)
                 if len(s) < 2:  # leave if end of file
                     break

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,9 +67,7 @@ def test_logo(capsys):
                `:|}$$$$}):`
 
         Analysis tool for idefix/pluto/fargo3d simulations (in polar coordinates).
-        """.lstrip(
-            "\n"
-        )
+        """.lstrip("\n")
     )
     expected += f"Version {__version__}\n"
     assert out == expected

--- a/tests/test_interfaces/test_binary_readers.py
+++ b/tests/test_interfaces/test_binary_readers.py
@@ -8,13 +8,12 @@ from nonos._readers.binary import NPYReader, VTKReader
 
 
 class TestVTKReader:
-
+    # fmt: off
     @pytest.mark.parametrize(
         "file,expected_fields",
         [
             (
                 ("micro_cubes", "micro_orszagtang.vtk"),
-                # fmt: off
                 [
                     "BX1","BX2", "BX3",
                     "PRS",
@@ -22,7 +21,6 @@ class TestVTKReader:
                     "TR0", "TR1",
                     "VX1", "VX2", "VX3"
                 ],
-                # fmt: on
             ),
             (
                 ("micro_cubes", "micro_disk.vtk"),
@@ -30,6 +28,7 @@ class TestVTKReader:
             ),
         ],
     )
+    # fmt: on
     def test_fields(self, test_data_dir, file, expected_fields):
         bd = VTKReader.read(test_data_dir.joinpath(*file))
         fields = sorted(bd.data.keys())

--- a/tests/test_interfaces/test_ini_readers.py
+++ b/tests/test_interfaces/test_ini_readers.py
@@ -26,7 +26,6 @@ def compile_to_Fargo3D(text: str) -> str:
 
 @pytest.mark.parametrize("reader", [Fargo3DReader, FargoADSGReader])
 class TestFargoReaders:
-
     def compile(self, text: str, reader: IniReader) -> str:
         if reader is FargoADSGReader:
             return compile_to_FargoADSG(text)

--- a/tests/test_interfaces/test_loader.py
+++ b/tests/test_interfaces/test_loader.py
@@ -7,7 +7,6 @@ from nonos.loaders import Loader, Recipe, loader_from, recipe_from
 
 
 class TestLoader:
-
     @pytest.fixture(params=Loader.__slots__, ids=lambda s: s.removesuffix("_"))
     def loader_slot(self, request):
         return request.param
@@ -185,7 +184,6 @@ class TestGetRecipe:
     ],
 )
 class TestLoaderFrom:
-
     def test_loaders_from_user_inputs(self, test_data_dir, parameter_file, code):
         parameter_file = test_data_dir.joinpath(*parameter_file)
         directory = parameter_file.parent


### PR DESCRIPTION
In the few minor ways ruff-format diverges from black, it's actually better, so let's save a hook.