### PR TITLE
MNT: deactivate pre-commit.ci autofixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autofix_prs: true
+  autofix_prs: false
   autoupdate_schedule: quarterly
 
 repos:


### PR DESCRIPTION
Avoid messy branch histories like we're seeing right now <img width="458" alt="Screenshot 2024-04-05 at 22 54 35" src="https://github.com/volodia99/nonos/assets/14075922/64c54149-d7d6-4493-9e4b-bf648a5d3e7b">
