### PR TITLE
RFC: simplify GasField.find_iphi

### DIFF
--- a/nonos/api/analysis.py
+++ b/nonos/api/analysis.py
@@ -691,7 +691,8 @@ class GasField:
 
     def find_iphi(self, phi=0):
         if self.native_geometry in ("polar", "spherical"):
-            return find_nearest(self.coords.phi, phi) % self.coords.phimed.shape[0]
+            mod = len(self.coords.phi) - 1
+            return find_nearest(self.coords.phi, phi) % mod
 
     def _load_planet(
         self,


### PR DESCRIPTION
avoiding a reference to phimed to simplify an upcoming, much more involved refactor