### PR TITLE
BUG: fix a bug where FargoADSG datasets would be loaded using a broken geometry flag

### DIFF
--- a/nonos/_readers/binary.py
+++ b/nonos/_readers/binary.py
@@ -609,7 +609,7 @@ class FargoADSGReader(_FargoReader):
         output_number, directory = _FargoReader._get_output_number_and_dir_from(file)
 
         V = BinData.default_init()
-        V["geometry"] = Geometry.CYLINDRICAL
+        V["geometry"] = Geometry.POLAR
         V["data"] = {}
 
         phi = np.loadtxt(directory / "used_azi.dat")[:, 0]


### PR DESCRIPTION
Fixes the critical part of #323. I'll follow up with a refactor to eliminate `Geometry.CYLINDRICAL`