### PR TITLE
RFC: drop Geometry CYLINDRICAL enum member

### DIFF
--- a/nonos/_types.py
+++ b/nonos/_types.py
@@ -42,7 +42,6 @@ FloatArray: TypeAlias = "np.ndarray[Any, np.dtype[np.float32 | np.float64]]"
 
 class Geometry(StrEnum):
     CARTESIAN = auto()
-    CYLINDRICAL = auto()
     POLAR = auto()
     SPHERICAL = auto()
 

--- a/tests/test_interfaces/test_binary_readers.py
+++ b/tests/test_interfaces/test_binary_readers.py
@@ -37,7 +37,7 @@ class TestVTKReader:
         # this simulation is in cartesian geometry
         file = test_data_dir / "micro_cubes" / "micro_orszagtang.vtk"
         with pytest.raises(ValueError):
-            VTKReader.read(file, geometry="cylindrical")
+            VTKReader.read(file, geometry="polar")
 
 
 class TestNPYReader:


### PR DESCRIPTION
A simplification towards fixing #323 but it's also revealing that we in fact do not already support cylindrical flags from idefix/pluto vtks.