### PR TITLE
TST: make numexpr an optional test dependency

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -37,7 +37,7 @@ jobs:
           --extra-index \
           https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
         python -m pip install .
-        python -m pip install --requirement requirements/tests.txt
+        python -m pip install --requirement requirements/tests_all.txt
 
     - run: python -m pip list
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
           python-version: '3.12'
 
     runs-on: ${{ matrix.os }}
+    env:
+      TEST_REQ_FILE: ${{ matrix.deps == 'minimal' && 'requirements/tests_min.txt' || 'requirements/tests_all.txt' }}
+
     steps:
     - uses: actions/checkout@v4
     - name: Setup Python
@@ -53,7 +56,16 @@ jobs:
     - name: Build
       run: |
         python -m pip install .
-        python -m pip install --requirement requirements/tests.txt
+
+    - name: Install test dependencies (UNIX)
+      if: matrix.os != 'windows-latest'
+      run: |
+        python -m pip install --requirement $TEST_REQ_FILE
+
+    - name: Install test dependencies (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        python -m pip install --requirement $env:TEST_REQ_FILE
 
     - run: python -m pip list
 
@@ -115,7 +127,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install .
-        python -m pip install --requirement requirements/tests.txt
+        python -m pip install --requirement requirements/tests_min.txt
 
     - name: Run Image Tests
       run: |

--- a/requirements/tests_all.txt
+++ b/requirements/tests_all.txt
@@ -1,0 +1,2 @@
+-r tests_min.txt
+numexpr>=2.8.3

--- a/requirements/tests_min.txt
+++ b/requirements/tests_min.txt
@@ -1,5 +1,4 @@
 cogapp>=3.3.0
-numexpr>=2.8.3
 pytest>=6.1
 pytest-mpl>=0.15.1
 coverage[toml]>=7.4.4

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,7 +1,6 @@
 import os
 
 import matplotlib.pyplot as plt
-import numexpr as ne
 import numpy.testing as npt
 import pytest
 from matplotlib.colors import SymLogNorm
@@ -135,6 +134,8 @@ def test_vmin_vmax_api(test_data_dir, temp_figure_and_axis):
 
 
 def test_compute_from_data(test_data_dir):
+    ne = pytest.importorskip("numexpr")
+
     directory = test_data_dir / "idefix_planet3d"
     os.chdir(directory)
 


### PR DESCRIPTION
This is meant to resolve an issue [seen in last night's CI](https://github.com/volodia99/nonos/actions/runs/9672974485/job/26686174204) where numpy 2.0.0 was installed on the minimal deps jobs via numexpr (unconstrained), which is not compatible with matplotlib 3.5.0