### PR TITLE
DEP: drop dependency on `rich` (replaced by atomic dependencies `termcolor` + `tqdm`)

### DIFF
--- a/nonos/logging.py
+++ b/nonos/logging.py
@@ -1,19 +1,18 @@
 import sys
+import unicodedata
 from typing import Union
 
 from loguru import logger
-from rich import print as rprint
-from rich.logging import RichHandler
+from termcolor import cprint
+
+_BONE_EMOJI = unicodedata.lookup("BONE")
 
 
 def configure_logger(level: Union[int, str] = 30, **kwargs) -> None:
     logger.remove()  # remove pre-existing handler
     logger.add(
-        RichHandler(
-            log_time_format="[%X] nonos",
-            omit_repeated_times=False,
-        ),
-        format="{message}",
+        sink=sys.stdout,
+        format="[{time:HH:mm:ss}] nonos <level>{level:<8}</level> {message}",
         level=level,
         **kwargs,
     )
@@ -21,18 +20,27 @@ def configure_logger(level: Union[int, str] = 30, **kwargs) -> None:
 
 def print_warn(message) -> None:
     """
-    adapted from idefix_cli (cmt robert)
-    https://github.com/neutrinoceros/idefix_cli
+    Pretty-print a warning.
     """
-    rprint(f":bone: [bold red]Warning[/] {message}", file=sys.stderr)
+    print(_BONE_EMOJI, end=" ", file=sys.stderr)
+    cprint("Warning", color="red", attrs=["bold"], end=" ", file=sys.stderr)
+    print(message, file=sys.stderr)
 
 
 def print_err(message) -> None:
     """
-    adapted from idefix_cli (cmt robert)
-    https://github.com/neutrinoceros/idefix_cli
+    Pretty-print an error message.
     """
-    rprint(f":bone: [bold white on red]Error[/] {message}", file=sys.stderr)
+    print(_BONE_EMOJI, end=" ", file=sys.stderr)
+    cprint(
+        "Error",
+        color="white",
+        on_color="on_red",
+        attrs=["bold"],
+        end=" ",
+        file=sys.stderr,
+    )
+    print(message, file=sys.stderr)
 
 
 def parse_verbose_level(verbose: int) -> str:
@@ -41,4 +49,4 @@ def parse_verbose_level(verbose: int) -> str:
     return level
 
 
-configure_logger(level=30)
+configure_logger(level="WARNING")

--- a/nonos/main.py
+++ b/nonos/main.py
@@ -9,6 +9,7 @@ import functools
 import importlib.resources as importlib_resources
 import os
 import re
+import sys
 import time
 from collections import ChainMap
 from importlib import import_module
@@ -21,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import inifix
 import numpy as np
 from packaging.version import Version
+from tqdm import tqdm
 
 from nonos.api import GasDataSet
 from nonos.api._angle_parsing import _parse_planet_file
@@ -588,17 +590,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         log_level=level,
     )
 
-    if args["progressBar"]:
-        from rich.progress import track
-    else:
-        # replace rich.progress.track with a no-op dummy
-        def track(it, *_args, **_kwargs):  # type: ignore [misc]
-            return it
-
     progress = functools.partial(
-        track,
-        description="Processing snapshots",
+        tqdm if args["progressBar"] else lambda it, *_arg, **_kwargs: it,
+        desc="Processing snapshots",
         total=len(args["on"]),
+        file=sys.stdout,
     )
 
     logger.info("Starting main loop")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,9 @@ dependencies = [
     "matplotlib>=3.5.0",
     "numpy>=1.19.3",
     "packaging>=20.0",
-    "rich>=10.13.0",
     "scipy>=1.6.1",
+    "termcolor>=2.1.0",
+    "tqdm>=4.64.1",
     "typing_extensions >= 4.4.0 ; python_version < '3.12'",
 ]
 


### PR DESCRIPTION
This is a step towards minimizing the total number of (direct+indirect) dependencies.
Switching to tqdm for progress bars also allows to fix a known bug where `-progressBar` has no effect with `-ncpu 1`
A minor setback I need to resolve is that tqdm doesn't interact with pytest as nicely as rich.progress, meaning that in `test_pbar`, we cannot accurately check wether the progress bar was cleaned up afterward, causing the test to fail, even though manual testing shows that the behavior matches what's intended.