### PR TITLE
ENH: (CLI): support colormap extension packages other than cblind (cmasher, cmocean, cmyt)

### DIFF
--- a/requirements/tests_all.txt
+++ b/requirements/tests_all.txt
@@ -1,2 +1,5 @@
 -r tests_min.txt
+cblind>=2.3.0
+cmocean>=3.0.3
+cmyt>=2.0.0
 numexpr>=2.8.3


### PR DESCRIPTION
In the process of removing cblind as a requirement, I also added support for other known colormap packages *if they are installed*. I'll need to add test coverage too before I undraft.