### PR TITLE
DEP: drop `cblind` as a hard dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
 requires-python = ">=3.9"
 
 dependencies = [
-    "cblind>=2.3.0",
     "inifix>=3.0.0",
     "lick>=0.5.1",
     "loguru>=0.5.3",


### PR DESCRIPTION
A natural follow up to #377