### PR TITLE
TST: filter a transitive deprecation warning from matplotlib 3.11 (dev)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ filterwarnings = [
     "error",
     'ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning', # https://github.com/dateutil/dateutil/pull/1285
     'ignore:The py23 module has been deprecated and will be removed in a future release:DeprecationWarning',
+    "ignore:Passing 'N' to ListedColormap is deprecated since:DeprecationWarning", # https://github.com/matplotlib/cmocean/pull/114
 ]
 
 [tool.mypy]


### PR DESCRIPTION
[example logs](https://github.com/volodia99/nonos/actions/runs/12031859520/job/33542335020)
I already patched cmyt, and opened a PR for cmocean https://github.com/matplotlib/cmocean/pull/114