### PR TITLE
TST: pin and upgrade GitHub Actions

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -28,12 +28,12 @@ jobs:
     name: Test nightly dependencies
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: 3.13-dev
-    - uses: astral-sh/setup-uv@v4
+    - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,9 +17,9 @@ jobs:
       id-token: write
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: 3.x
     - name: Install build dependencies
@@ -29,4 +29,4 @@ jobs:
       run: python -m build
     - name: Publish package distributions to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,12 @@ jobs:
       TEST_REQ_FILE: ${{ matrix.deps == 'minimal' && 'requirements/tests_min.txt' || 'requirements/tests_all.txt' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@v4
+    - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -86,7 +86,7 @@ jobs:
       # only using reports from ubuntu because
       # combining reports from multiple platforms is tricky (or impossible ?)
       if: startsWith(matrix.os, 'ubuntu')
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: nonos_coverage_data-${{ matrix.os }}-${{ matrix.python-version }}
         path: .coverage.*
@@ -107,12 +107,12 @@ jobs:
     name: type-checking
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@v4
+    - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -128,12 +128,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
       with:
         python-version: 3.x
-    - uses: astral-sh/setup-uv@v4
+    - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -164,14 +164,14 @@ jobs:
     # (and especially) in case of failure.
     - name: Upload pytest-mpl report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: nonos_pytest_mpl_results
         path: nonos_pytest_mpl_results/*
 
     - name: Upload pytest-mpl baseline
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: nonos_pytest_mpl_new_baseline
         path: nonos_pytest_mpl_new_baseline/*
@@ -183,13 +183,13 @@ jobs:
     needs: tests
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
 
     # Use latest Python, so it understands all syntax.
     - run: uv tool install --python 3.13 coverage
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         pattern: nonos_coverage_data-*
         merge-multiple: true
@@ -201,7 +201,7 @@ jobs:
         coverage report --fail-under=80
 
     - name: Upload HTML report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: nonos_coverage_report
         path: htmlcov
@@ -216,8 +216,8 @@ jobs:
       cancel-in-progress: true
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4.2.0
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -228,7 +228,7 @@ jobs:
       run: |
         uvx --with-requirements=requirements/docs.txt mkdocs build
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:
         name: site
         path: site


### PR DESCRIPTION
Obtained via `gha-update`. Dependabot can still handle this format.