### PR TITLE
REL: bump pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,4 +29,4 @@ jobs:
       run: python -m build
     - name: Publish package distributions to PyPI
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-      uses: pypa/gh-action-pypi-publish@15c56dba361d8335944d31a2ecd17d700fc7bcbc # v1.12.2
+      uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3


### PR DESCRIPTION
- the current latest version of hatchling (1.27.0) using METADATA format 2.4
- pypa/gh-action-pypi-publish 1.12.2 not supporting this format version
