### PR TITLE
TYP: ignore an unfixable pyright error

### DIFF
--- a/src/nonos/main.py
+++ b/src/nonos/main.py
@@ -604,7 +604,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     tstart = time.time()
     if ncpu == 1:
         for on in progress(args["on"]):
-            process_field(on, **func_kwargs)
+            process_field(on, **func_kwargs)  # pyright: ignore[reportArgumentType]
     else:
         func = functools.partial(process_field, **func_kwargs)
         with Pool(ncpu) as pool:


### PR DESCRIPTION
This single line is flagged multiple times by pyright because the `func_kwargs` dictionary has many unknown types. The root cause being that many of its values come straight from `argparse` APIs, which are basically un-checkable, so I'll ignore them for now (and probably for ever) to reduce the level of noise.