### PR TITLE
BLD: switch build backend to `flit-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "nonos"
@@ -28,6 +28,7 @@ dependencies = [
     "tqdm>=4.64.1",
     "typing_extensions >= 4.4.0 ; python_version < '3.12'",
 ]
+license = { file = "LICENSE" }
 
 [project.optional-dependencies]
 all = [
@@ -37,9 +38,6 @@ all = [
     "lick>=0.5.1",
     "scipy>=1.6.1",
 ]
-
-[project.license]
-text = "GPL-3.0"
 
 [project.readme]
 file = "README.md"
@@ -73,18 +71,6 @@ docs = [
     "mkdocs-include-markdown-plugin>=7.1.2",
     "mkdocs-material>=9.5.47",
     "mkdocstrings[python]>=0.27.0",
-]
-
-[tool.hatch.build.targets.sdist]
-exclude = [
-    "tests",
-    ".github",
-    "docs",
-    "mkdocs.yml",
-    "_typos.toml",
-    ".readthedocs.yaml",
-    ".pre-commit-config.yaml",
-    ".gitignore",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Follow up to #359

Even better than hatchling for nonos' needs:
- 0 dependencies
- publish artifacts are minimal by default (while hatchling requires fine tuning)